### PR TITLE
updated broken discord link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -64,7 +64,7 @@
 			Pax is a user interface language and rendering engine.  Use Pax to build low-level, high-performance GUIs and interactive 2D graphics with Rust.<br />
 			Pax is currently available in <a href="https://docs.pax.rs/status-sept-2022.html">alpha preview</a>.<br /><br />
 			<div class="links" style="color: black; font-size: 20px;">
-				<a href="https://docs.pax.rs/">Docs</a> | <a href="https://www.github.com/pax-lang/pax">GitHub</a> | <a href="https://discord.gg/5zXsskAzRB">Discord</a> | <a href="https://developing.pax.rs">Blog</a>
+				<a href="https://docs.pax.rs/">Docs</a> | <a href="https://www.github.com/pax-lang/pax">GitHub</a> | <a href="https://discord.gg/Eq8KWAUc6b">Discord</a> | <a href="https://developing.pax.rs">Blog</a>
 			</div>
 			
 		</div>


### PR DESCRIPTION
Current discord link is invalid (due to timelimit?) so generated a new discord link that never expires. 